### PR TITLE
Avoid using the bundle name org.apache.commons.commons-logging

### DIFF
--- a/plugins/org.eclipse.wst.server.preview/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.wst.server.preview/META-INF/MANIFEST.MF
@@ -7,8 +7,7 @@ Bundle-Activator: org.eclipse.wst.server.preview.internal.PreviewServerPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.wst.server.preview.internal;x-internal:=true
-Require-Bundle: org.apache.commons.commons-logging;bundle-version="[1.0.4,2.0.0)",
- org.eclipse.core.runtime;bundle-version="[3.21.0,4.0.0)",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.21.0,4.0.0)",
  org.eclipse.jetty.ee8.plus;bundle-version="12.0.3",
  org.eclipse.jetty.ee8.server;bundle-version="12.0.3",
  org.eclipse.jetty.ee8.servlet;bundle-version="12.0.3",
@@ -22,6 +21,7 @@ Require-Bundle: org.apache.commons.commons-logging;bundle-version="[1.0.4,2.0.0)
 Import-Package: javax.servlet;version="[4.0.0,5.0.0)",
  javax.servlet.http;version="[4.0.0,5.0.0)",
  javax.transaction.xa,
+ org.apache.commons.logging;version="[1.2.0,2.0.0)",
  org.slf4j
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17


### PR DESCRIPTION
- Rely purely on package imports of org.apache.commons.logging that include version 1.2.0 in the range.

https://github.com/eclipse-orbit/orbit-simrel/issues/40